### PR TITLE
fix: run postinstall after cache restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: npm ci
         run: npm ci
         if: steps.npm-cache.outputs.cache-hit != 'true'
+      - name: Run postinstall
+        run: npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit == 'true'
       - run: npm run type-check
       - run: npm test
       - name: install playwright dependencies

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,6 +32,9 @@ jobs:
       - name: npm ci
         run: npm ci
         if: steps.npm-cache.outputs.cache-hit != 'true'
+      - name: Run postinstall
+        run: npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit == 'true'
       - run: npm run type-check
       - run: npm test
       - name: install playwright dependencies

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,9 +7,12 @@ on:
 
 jobs:
   pr:
+    name: pr (ubuntu-24.04, attempt ${{ matrix.attempt }})
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-2022]
+        os: [ubuntu-24.04]
+        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,12 +7,9 @@ on:
 
 jobs:
   pr:
-    name: pr (ubuntu-24.04, attempt ${{ matrix.attempt }})
     strategy:
-      fail-fast: false
       matrix:
-        os: [ubuntu-24.04]
-        attempt: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        os: [ubuntu-24.04, macos-14, windows-2022]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
       - name: npm ci
         run: npm ci
         if: steps.npm-cache.outputs.cache-hit != 'true'
+      - name: Run postinstall
+        run: npm run postinstall
+        if: steps.npm-cache.outputs.cache-hit == 'true'
       - run: npm run type-check
       - run: npm test
       - name: install playwright dependencies


### PR DESCRIPTION
Rebuilds generated extension and HTML worker bundles after restoring the node_modules cache in PR, main, and release workflows. This fixes the cache-hit e2e failure blocking #177.