### PR TITLE
feature: update extension api to 8.75.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1480,6 +1480,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@lvce-editor/api": {
+      "version": "8.75.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.75.0.tgz",
+      "integrity": "sha512-ub0W95GZVxRmUYpkfGHirV8+UUO15uZCBxkhdgtctzLWuw1SZQO3UEcBqKhTbPsiRCzawclHDXRFR0N9vFGboQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/command": "^2.0.0",
+        "@lvce-editor/rpc": "^6.4.0",
+        "@lvce-editor/rpc-registry": "^9.24.0",
+        "@lvce-editor/virtual-dom-worker": "^10.0.0"
+      }
+    },
     "node_modules/@lvce-editor/assert": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.7.0.tgz",
@@ -10591,19 +10604,7 @@
       "name": "builtin.language-features-html",
       "version": "0.0.0-dev",
       "devDependencies": {
-        "@lvce-editor/api": "^8.61.0"
-      }
-    },
-    "packages/extension/node_modules/@lvce-editor/api": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/api/-/api-8.61.0.tgz",
-      "integrity": "sha512-lAYmT0vTwuoWN+m27t+DvrzmtYjUL8gyyy0pUsObOmia8dZHmUV3vhzgWfMaafKRJvAHpal78aqHsAgbBw1XUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/rpc": "^6.4.0",
-        "@lvce-editor/rpc-registry": "^9.24.0",
-        "@lvce-editor/virtual-dom-worker": "^10.0.0"
+        "@lvce-editor/api": "^8.75.0"
       }
     },
     "packages/html-data": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "type": "module",
   "devDependencies": {
-    "@lvce-editor/api": "^8.61.0"
+    "@lvce-editor/api": "^8.75.0"
   }
 }


### PR DESCRIPTION
Update the extension API to 8.75.0 so unused extension commands can be removed from the production bundle. This removes about 30 KB from the extension bundle without changing behavior.