### PR TITLE
fix: auto close html tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1478,7 +1478,8 @@
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@lvce-editor/api": {
       "version": "8.75.0",
@@ -1494,23 +1495,10 @@
       }
     },
     "node_modules/@lvce-editor/assert": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.7.0.tgz",
-      "integrity": "sha512-l9fHl7KDYAm4ou/B88fiRYVguA7z5Fx4lC8SmCLuCJFeXfjqPFh7rnGysToPNssmcPAEdwOgXvH+5U4v2V6q5Q==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.9.0.tgz",
+      "integrity": "sha512-EPOXml+iWU38g0h71yv/nPaL1Xz/S72ICORPrR8shtoTqeoZmFzD8bH1dphr/xzYPaU97yEQo1Zen33aH111Uw==",
       "license": "MIT"
-    },
-    "node_modules/@lvce-editor/auth-process": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.10.0.tgz",
-      "integrity": "sha512-GlyU+4vJG88eSRsp9rjcj/ZDGRKR8oYKFAKB7pKA8ovSz9OlS14ddnqlaS5uZ6zpD2u5D6iS2eO78AeSvAaiBg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "auth-process": "bin/oauthProcess.js"
-      },
-      "engines": {
-        "node": ">=24"
-      }
     },
     "node_modules/@lvce-editor/command": {
       "version": "2.0.0",
@@ -1526,9 +1514,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.10.0.tgz",
-      "integrity": "sha512-mEKsVl6i/Qd/YQuFvzr6806pg6YIq0vo9AQ1v42U7ir+7sD3y3fvUcEL7yyOrC2+CimeoByj8BTEHHMFJNuB2w==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.15.0.tgz",
+      "integrity": "sha512-Z9B7YS7KAzia8lI1XR4Grx5Rl+OX2ow5PuAePLh1n4gx5BB40VeJX7Jj9scOZRclUQQmhCkH6MQt28jhIXNQ4A==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1540,33 +1528,31 @@
       }
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.93.25",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.93.25.tgz",
-      "integrity": "sha512-VjZQBRdIKJ80t2kBCsG2owFZooH4Lxs7B9KRaVpWKPqv8uZwR2L2MIzBXzxB56ifWABIBszxuLR5449BTWhfnw==",
+      "version": "0.99.17",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.99.17.tgz",
+      "integrity": "sha512-jHWmvJ7SCzo/PVaTs2QSXRM1dsarK+lOpy6MQf/ZTwgRcryg3LKOfHJ56G/wsyXvrTY74Me6sp6MdhZ85Gu0Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "^1.7.0",
-        "@lvce-editor/rpc": "^6.8.0",
-        "@lvce-editor/verror": "^1.7.0",
-        "execa": "^9.6.1",
-        "got": "^15.1.0",
-        "minimist": "^1.2.8"
+        "@lvce-editor/assert": "^1.9.0",
+        "@lvce-editor/command": "^2.0.0",
+        "@lvce-editor/rpc": "^6.16.0",
+        "@lvce-editor/verror": "^1.7.0"
       },
       "engines": {
         "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.5.1.tgz",
-      "integrity": "sha512-kmVihRCa4LpcgwC4KN+jtdYuAAn+2UWfjtBaAZmuDLVqElQnn+lExWvjQoD3U2dOble9WU9/Y8uX5ejRI4mJEQ==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.12.0.tgz",
+      "integrity": "sha512-fHn8/9SNNsvTXhekJBCHZ24+ZsBHaisjPep7mipuAeWxTUdN6KTyfY9hpleKPv/VOlA1o4ENueQkNFhoFesftw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "trash": "^10.1.1",
-        "ws": "^8.21.0"
+        "ws": "^8.21.1"
       },
       "bin": {
         "file-system-process": "bin/fileSystemProcess.js"
@@ -1576,9 +1562,9 @@
       }
     },
     "node_modules/@lvce-editor/file-watcher-process": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.6.3.tgz",
-      "integrity": "sha512-Kjxgiv4HfJ3tDVicgfjzpBQLxZtUs4N5AjcSui3sl9pxvoW6kYhv13BakIaBXlvxpOsHSsbKITRwkCtmu0cJ+g==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.12.0.tgz",
+      "integrity": "sha512-3nLW4QWoH9eLpQ2bcKrawNxH7q2aLbdH0+E19kmlukOTM+HWmIj9dnJKr3zPiOKOnUjE/S0bZwB1gL+2Arbd4g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1594,25 +1580,24 @@
       }
     },
     "node_modules/@lvce-editor/ipc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.4.0.tgz",
-      "integrity": "sha512-CxMjWxF/NjoAwa2B5/hFzuXuPVSSTY2tM4khlLopXTqIHbkPJzo6FAAkBI8NRqabchRYCDDpvaO+IvASWwp+Zw==",
-      "dev": true,
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.10.0.tgz",
+      "integrity": "sha512-iL4D4ou4iSOvVu2S7/L20JHDavOYcA0o2y8HDQYdksBkK52Dlbt4U1f96DC2FMfKl/6uTBuZFNL8hCapYZMa6w==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0"
+        "@lvce-editor/web-socket-server": "^2.1.0",
+        "ws": "^8.21.1"
       },
       "engines": {
         "node": ">=22"
       }
     },
     "node_modules/@lvce-editor/json-rpc": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.3.0.tgz",
-      "integrity": "sha512-P05TN3OvSVP0LkcG8xE79mGom/i89ttEJq3RfqRwv0sKvSi77NEp9JU3NGANNtBkbFuNWr8s6+XmSmhcj/3ahg==",
-      "dev": true,
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.6.0.tgz",
+      "integrity": "sha512-T9zeMKn7Yk6QpMVY/RK5YzCp3VnG53jyHJ7gbC+CukuzlXMngj/TzR1mNkqEK8X3rFG+fxOAHrRKik+EE4cVAQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/jsonc-parser": {
@@ -1995,9 +1980,9 @@
       }
     },
     "node_modules/@lvce-editor/process-explorer": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.12.0.tgz",
-      "integrity": "sha512-BrGgUrk7BwWS5hm6KczqksVD9bIYVMjaQh2njxt3ZDn2dURXAcNtyfWJlnXelAw7ccUWJXNaS0GlUZxPVG7aXA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.14.0.tgz",
+      "integrity": "sha512-PfJKcKPyqoxOhMJLXFMSTz9mrzWvK+rYgo3lZQQFBdEEwuC/m8laV4eppvKMucWsLJPfTCKFc1gtMqpXfSLUVw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2011,12 +1996,15 @@
       }
     },
     "node_modules/@lvce-editor/pty-host": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.3.0.tgz",
-      "integrity": "sha512-g2hTRb7lSc3uZaLq54dthlNG9ANG6eyJYPMih/WMqq+8GSoRblhbZZhsUpJdpaTb7hnwcsJ3y0LK5X8IKm2tDQ==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.7.0.tgz",
+      "integrity": "sha512-wx/4AUOJJfPVBlgueNrF/lFODN2575KIwfE5vHCl26jFr8qWJHvmypv/91eoq4whA5wGzH+tjEvO4t4FT8GSrg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "dependencies": {
+        "@lvce-editor/command": "^2.0.0"
+      },
       "bin": {
         "pty-host": "bin/ptyHost.js"
       },
@@ -2025,9 +2013,9 @@
       }
     },
     "node_modules/@lvce-editor/ripgrep": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-5.4.0.tgz",
-      "integrity": "sha512-9Y6xyk24MuVwz6WDv9SWyxVC351x1H/yHr2yaU5iuf0snnlGKOX4ix/QpniiESDHjlJn74B2V/h6DI4kwxckkQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-5.5.0.tgz",
+      "integrity": "sha512-k4VM7TG6/dENvTqiuJJZtSr4x9ZCzCnRsUVZFijVexPSvR0JmHY6MC1gAcLeb13kQbtL/CVJZNJ/sk64JSMSeg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2052,207 +2040,6 @@
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.36.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.36.0.tgz",
-      "integrity": "sha512-fbV4xYg0jZn06TcicEOm0wM+kA23OXZk+NK3QZsjNCIBdl0Pv6+V0GiR1aAbU+wlMmbLuHkEpmtSXfoBKrbGBw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.19.0",
-        "@lvce-editor/rpc": "^6.4.0"
-      }
-    },
-    "node_modules/@lvce-editor/rpc/node_modules/@lvce-editor/ipc": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.10.0.tgz",
-      "integrity": "sha512-iL4D4ou4iSOvVu2S7/L20JHDavOYcA0o2y8HDQYdksBkK52Dlbt4U1f96DC2FMfKl/6uTBuZFNL8hCapYZMa6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0",
-        "ws": "^8.21.1"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@lvce-editor/rpc/node_modules/@lvce-editor/json-rpc": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.4.0.tgz",
-      "integrity": "sha512-P88S6+tTtDTk7esMVwdVxhNeVE0SszWOS6HFflVmza/T/MvKQ88KjYJqTACd+6MWQmw+ZHV8hLwdL+9YXLfIoQ==",
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/search-process": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.1.0.tgz",
-      "integrity": "sha512-GlRDR+Mgy/ln2+J1UiYeAvTxkamnVAOXfsJwp6N4SpQllh1+3zKUjDduUIABakoIIP13Fk4InF0b9VQI/wvrew==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@lvce-editor/constants": "^5.14.0",
-        "execa": "^9.6.1",
-        "ws": "^8.21.0"
-      },
-      "bin": {
-        "search-process": "bin/searchProcess.js"
-      },
-      "engines": {
-        "node": ">=24"
-      },
-      "optionalDependencies": {
-        "@lvce-editor/ripgrep": "^5.1.0"
-      }
-    },
-    "node_modules/@lvce-editor/server": {
-      "version": "0.99.17",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.99.17.tgz",
-      "integrity": "sha512-v+sjeutvkXXJEGOYV6P58ghozX5blpEHlKWY0qrZ/mHIeL48U65+anF43lMUTsbEbOCqLK/GnG/f5a9RcvwwdQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/shared-process": "0.99.17",
-        "@lvce-editor/static-server": "0.99.17"
-      },
-      "bin": {
-        "server": "bin/server.js"
-      },
-      "engines": {
-        "node": ">=24"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/assert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.9.0.tgz",
-      "integrity": "sha512-EPOXml+iWU38g0h71yv/nPaL1Xz/S72ICORPrR8shtoTqeoZmFzD8bH1dphr/xzYPaU97yEQo1Zen33aH111Uw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/embeds-process": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.15.0.tgz",
-      "integrity": "sha512-Z9B7YS7KAzia8lI1XR4Grx5Rl+OX2ow5PuAePLh1n4gx5BB40VeJX7Jj9scOZRclUQQmhCkH6MQt28jhIXNQ4A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "embeds-process": "bin/embedsProcess.js"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.99.17",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.99.17.tgz",
-      "integrity": "sha512-jHWmvJ7SCzo/PVaTs2QSXRM1dsarK+lOpy6MQf/ZTwgRcryg3LKOfHJ56G/wsyXvrTY74Me6sp6MdhZ85Gu0Gg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.9.0",
-        "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/rpc": "^6.16.0",
-        "@lvce-editor/verror": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=24"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/file-system-process": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.12.0.tgz",
-      "integrity": "sha512-fHn8/9SNNsvTXhekJBCHZ24+ZsBHaisjPep7mipuAeWxTUdN6KTyfY9hpleKPv/VOlA1o4ENueQkNFhoFesftw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "trash": "^10.1.1",
-        "ws": "^8.21.1"
-      },
-      "bin": {
-        "file-system-process": "bin/fileSystemProcess.js"
-      },
-      "engines": {
-        "node": ">=24"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/file-watcher-process": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.12.0.tgz",
-      "integrity": "sha512-3nLW4QWoH9eLpQ2bcKrawNxH7q2aLbdH0+E19kmlukOTM+HWmIj9dnJKr3zPiOKOnUjE/S0bZwB1gL+2Arbd4g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "chokidar": "^5.0.0"
-      },
-      "bin": {
-        "file-watcher-process": "bin/fileWatcherProcess.js"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/ipc": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.10.0.tgz",
-      "integrity": "sha512-iL4D4ou4iSOvVu2S7/L20JHDavOYcA0o2y8HDQYdksBkK52Dlbt4U1f96DC2FMfKl/6uTBuZFNL8hCapYZMa6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0",
-        "ws": "^8.21.1"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/json-rpc": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.6.0.tgz",
-      "integrity": "sha512-T9zeMKn7Yk6QpMVY/RK5YzCp3VnG53jyHJ7gbC+CukuzlXMngj/TzR1mNkqEK8X3rFG+fxOAHrRKik+EE4cVAQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/process-explorer": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.14.0.tgz",
-      "integrity": "sha512-PfJKcKPyqoxOhMJLXFMSTz9mrzWvK+rYgo3lZQQFBdEEwuC/m8laV4eppvKMucWsLJPfTCKFc1gtMqpXfSLUVw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "process-explorer": "bin/processExplorer.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@vscode/windows-process-tree": "^0.8.0"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/pty-host": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.7.0.tgz",
-      "integrity": "sha512-wx/4AUOJJfPVBlgueNrF/lFODN2575KIwfE5vHCl26jFr8qWJHvmypv/91eoq4whA5wGzH+tjEvO4t4FT8GSrg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@lvce-editor/command": "^2.0.0"
-      },
-      "bin": {
-        "pty-host": "bin/ptyHost.js"
-      },
-      "optionalDependencies": {
-        "node-pty": "1.1.0-beta34"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/rpc-registry": {
       "version": "9.48.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.48.0.tgz",
       "integrity": "sha512-GHbf/Nzn2x30gk6cS600LVnbbPwUCPnjxtG9Kl0AHtUNx6SYeFKCfA/LftEUKg934TEG1WcvSkgo1vG3s0m9Bw==",
@@ -2264,7 +2051,7 @@
         "@lvce-editor/rpc": "^6.4.0"
       }
     },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/search-process": {
+    "node_modules/@lvce-editor/search-process": {
       "version": "15.7.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.7.0.tgz",
       "integrity": "sha512-eAyrQ8TakmyKXffDy0hDcsKVoZ6du44kos4XFeDnedfsd1znIBrsnF6mMplixMdL619Cd90kTXA739B7QMorRg==",
@@ -2285,7 +2072,24 @@
         "@lvce-editor/ripgrep": "^5.2.0"
       }
     },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/shared-process": {
+    "node_modules/@lvce-editor/server": {
+      "version": "0.99.17",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.99.17.tgz",
+      "integrity": "sha512-v+sjeutvkXXJEGOYV6P58ghozX5blpEHlKWY0qrZ/mHIeL48U65+anF43lMUTsbEbOCqLK/GnG/f5a9RcvwwdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/shared-process": "0.99.17",
+        "@lvce-editor/static-server": "0.99.17"
+      },
+      "bin": {
+        "server": "bin/server.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@lvce-editor/shared-process": {
       "version": "0.99.17",
       "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.99.17.tgz",
       "integrity": "sha512-dPsWD0rZZKKd6qsykbCPraRU1j0c8i8tmPieRz1GOjRcfep90/rzd+qRtYScnthJQq7gaB5ejesnAFjm01JyNg==",
@@ -2324,145 +2128,6 @@
         "trash": "^10.1.1"
       }
     },
-    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.8.0.tgz",
-      "integrity": "sha512-kJ/NDVYT/KirvB/qAo8f0rVDJKgaRyCrYZ5c5W8B2bQ4iQLnQ68FHJcIKypRa6vN7bfI544xfl7laqMOhZZ28w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "typescript-compile-process": "bin/typescriptCompileProcess.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/argparse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
-      "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "Python-2.0"
-    },
-    "node_modules/@lvce-editor/server/node_modules/entities": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
-      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/linkify-it": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
-      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/markdown-it"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^3.0.0"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/markdown-it": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.0.tgz",
-      "integrity": "sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/markdown-it"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^3.0.0",
-        "entities": "^8.0.0",
-        "linkify-it": "^6.0.0",
-        "mdurl": "^2.1.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^3.0.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/@lvce-editor/server/node_modules/uc.micro": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
-      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/shared-process": {
-      "version": "0.93.25",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.93.25.tgz",
-      "integrity": "sha512-+ny25vPmpvwIVzL0DnJZRjL9EsuA2npjkCp43e5O4sZCjMC2RS62QDd+J7fUTQRIDiBB6fHIMH1Eq8cvK66qsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "1.7.0",
-        "@lvce-editor/auth-process": "1.10.0",
-        "@lvce-editor/extension-host-helper-process": "0.93.25",
-        "@lvce-editor/ipc": "16.4.0",
-        "@lvce-editor/json-rpc": "8.3.0",
-        "@lvce-editor/jsonc-parser": "1.5.0",
-        "@lvce-editor/pretty-error": "2.0.0",
-        "@lvce-editor/process-explorer": "3.12.0",
-        "@lvce-editor/rpc-registry": "9.36.0",
-        "@lvce-editor/verror": "1.7.0",
-        "is-object": "^1.0.2",
-        "markdown-it": "^14.3.0",
-        "xdg-basedir": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=24"
-      },
-      "optionalDependencies": {
-        "@lvce-editor/embeds-process": "4.10.0",
-        "@lvce-editor/file-system-process": "5.5.1",
-        "@lvce-editor/file-watcher-process": "4.6.3",
-        "@lvce-editor/network-process": "5.2.0",
-        "@lvce-editor/preload": "1.5.0",
-        "@lvce-editor/preview-process": "11.0.0",
-        "@lvce-editor/pty-host": "8.3.0",
-        "@lvce-editor/search-process": "15.1.0",
-        "@lvce-editor/typescript-compile-process": "5.4.0",
-        "open": "^11.0.0",
-        "tail": "^2.2.6",
-        "tmp-promise": "^3.0.3",
-        "trash": "^10.1.1"
-      }
-    },
     "node_modules/@lvce-editor/static-server": {
       "version": "0.99.17",
       "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.99.17.tgz",
@@ -2474,9 +2139,9 @@
       }
     },
     "node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.4.0.tgz",
-      "integrity": "sha512-nBHfHtqiWTMDJpdsq3xju/RdL8LLH/rsUzcda0y0wbSlmG0PmCOvNIN3LA+FfLX+FpHtDk41JRc7TGZ0vW971Q==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.8.0.tgz",
+      "integrity": "sha512-kJ/NDVYT/KirvB/qAo8f0rVDJKgaRyCrYZ5c5W8B2bQ4iQLnQ68FHJcIKypRa6vN7bfI544xfl7laqMOhZZ28w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3920,19 +3585,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@sindresorhus/is": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
-      "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -4045,7 +3697,8 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -4731,10 +4384,20 @@
       }
     },
     "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
+      "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "Python-2.0"
     },
     "node_modules/array-uniq": {
@@ -5130,6 +4793,7 @@
       "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=20"
       },
@@ -5143,6 +4807,7 @@
       "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=14.16"
       }
@@ -5153,6 +4818,7 @@
       "integrity": "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@types/http-cache-semantics": "^4.2.0",
         "get-stream": "^9.0.1",
@@ -5172,6 +4838,7 @@
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
         "is-stream": "^4.0.1"
@@ -5189,6 +4856,7 @@
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=18"
       },
@@ -5262,19 +4930,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/chunk-data": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chunk-data/-/chunk-data-0.1.0.tgz",
-      "integrity": "sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chunkify": {
@@ -5450,6 +5105,7 @@
       "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mimic-response": "^4.0.0"
       },
@@ -5565,13 +5221,13 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=0.12"
+        "node": ">=20.19.0"
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
@@ -6107,33 +5763,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/got": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-15.1.0.tgz",
-      "integrity": "sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/is": "^8.0.0",
-        "byte-counter": "^0.1.0",
-        "cacheable-lookup": "^7.0.0",
-        "cacheable-request": "^13.0.18",
-        "chunk-data": "^0.1.0",
-        "decompress-response": "^10.0.0",
-        "http2-wrapper": "^2.2.1",
-        "keyv": "^5.6.0",
-        "lowercase-keys": "^4.0.1",
-        "responselike": "^4.0.2",
-        "type-fest": "^5.6.0",
-        "uint8array-extras": "^1.5.0"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6206,7 +5835,8 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
@@ -6214,6 +5844,7 @@
       "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -7780,6 +7411,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -7861,9 +7493,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
-      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
       "dev": true,
       "funding": [
         {
@@ -7877,7 +7509,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "uc.micro": "^2.0.0"
+        "uc.micro": "^3.0.0"
       }
     },
     "node_modules/lodash.memoize": {
@@ -7886,19 +7518,6 @@
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lowercase-keys": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-4.0.1.tgz",
-      "integrity": "sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -7954,9 +7573,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
-      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.0.tgz",
+      "integrity": "sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==",
       "dev": true,
       "funding": [
         {
@@ -7970,12 +7589,12 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.5.0",
-        "linkify-it": "^5.0.2",
-        "mdurl": "^2.0.0",
+        "argparse": "^3.0.0",
+        "entities": "^8.0.0",
+        "linkify-it": "^6.0.0",
+        "mdurl": "^2.1.0",
         "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
+        "uc.micro": "^3.0.0"
       },
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
@@ -8051,6 +7670,7 @@
       "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -8223,6 +7843,7 @@
       "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -8778,6 +8399,7 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -8802,9 +8424,9 @@
       "license": "MIT"
     },
     "node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -8884,7 +8506,8 @@
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -8925,6 +8548,7 @@
       "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "lowercase-keys": "^3.0.0"
       },
@@ -8941,6 +8565,7 @@
       "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -9343,19 +8968,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
-      }
-    },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tail": {
@@ -9785,22 +9397,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/type-fest": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
-      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -9816,9 +9412,9 @@
       }
     },
     "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
       "dev": true,
       "license": "MIT"
     },
@@ -9834,19 +9430,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/uint8array-extras": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
-      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unbash": {
@@ -10268,7 +9851,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/shared-process": "^0.93.19"
+        "@lvce-editor/shared-process": "^0.99.17"
       }
     },
     "packages/e2e": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@lvce-editor/package-extension": "^3.2.0",
-        "@lvce-editor/server": "^0.93.19",
+        "@lvce-editor/server": "^0.99.17",
         "jest": "^30.4.2",
         "knip": "^6.29.0",
         "ts-jest": "^29.4.11",
@@ -1519,9 +1519,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.22.0.tgz",
-      "integrity": "sha512-yjT2rnsk+1jRoda5ZnU7ENjunjvqfsa6Lr4ydO+88K/dE0ifoZQN3VtH+8eeZBCMTw8sBT71X/d4aM1aX5b2Vg==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.26.0.tgz",
+      "integrity": "sha512-vh+dSf+oLjS+ekKOnHHDuP8NUSM3ps/Ir15yCJlGDFw82ZqQeWqAiJyIx3Gsa2XDw77ZKDVfxr9wTHgPIaRu3g==",
       "dev": true,
       "license": "MIT"
     },
@@ -1540,9 +1540,9 @@
       }
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.93.19",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.93.19.tgz",
-      "integrity": "sha512-O2nXkS8t6OVKRlehR0xPNrUcpmfqNcrvgPYucgKPBa61ETnPTxHL55hV428BuGAMGEOb+UN/JiniRc4NfwcKPA==",
+      "version": "0.93.25",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.93.25.tgz",
+      "integrity": "sha512-VjZQBRdIKJ80t2kBCsG2owFZooH4Lxs7B9KRaVpWKPqv8uZwR2L2MIzBXzxB56ifWABIBszxuLR5449BTWhfnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1555,171 +1555,6 @@
       },
       "engines": {
         "node": ">=24"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@lvce-editor/extension-host-helper-process/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
@@ -1762,6 +1597,7 @@
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.4.0.tgz",
       "integrity": "sha512-CxMjWxF/NjoAwa2B5/hFzuXuPVSSTY2tM4khlLopXTqIHbkPJzo6FAAkBI8NRqabchRYCDDpvaO+IvASWwp+Zw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -1854,69 +1690,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lvce-editor/network-process/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -1987,17 +1760,6 @@
         "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
     "node_modules/@lvce-editor/network-process/node_modules/ignore": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
@@ -2018,59 +1780,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/keyv": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/@lvce-editor/network-process/node_modules/lowercase-keys": {
@@ -2118,24 +1827,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lvce-editor/network-process/node_modules/open": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
@@ -2170,20 +1861,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lvce-editor/network-process/node_modules/pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -2195,20 +1872,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@lvce-editor/network-process/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@lvce-editor/network-process/node_modules/slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -2218,20 +1881,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@lvce-editor/network-process/node_modules/trash": {
@@ -2304,171 +1953,6 @@
         "execa": "^9.6.1",
         "rollup": "^4.53.3",
         "tar-fs": "^3.1.1"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@lvce-editor/package-extension/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@lvce-editor/preload": {
@@ -2555,14 +2039,14 @@
       }
     },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.10.0.tgz",
-      "integrity": "sha512-yOvmhLpnRIbfa0/PmlIUOnP9hWscuYomztFNzj9Rkv/R2QpptmqC/xZKYNONIkT6yg+SWmWnhbl/6q98zxFIZQ==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.16.0.tgz",
+      "integrity": "sha512-NK9k9/L3fWhwy3j3zrG0ffqHE+9SZ7DevvKcTkrrbgKAS3/L/pAJsTI9MuD8F+18oJEncjCmFTr26+CK3aPSgA==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^16.4.0",
+        "@lvce-editor/ipc": "^16.9.0",
         "@lvce-editor/json-rpc": "^8.4.0",
         "@lvce-editor/verror": "^1.7.0"
       }
@@ -2577,6 +2061,21 @@
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/constants": "^5.19.0",
         "@lvce-editor/rpc": "^6.4.0"
+      }
+    },
+    "node_modules/@lvce-editor/rpc/node_modules/@lvce-editor/ipc": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.10.0.tgz",
+      "integrity": "sha512-iL4D4ou4iSOvVu2S7/L20JHDavOYcA0o2y8HDQYdksBkK52Dlbt4U1f96DC2FMfKl/6uTBuZFNL8hCapYZMa6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/verror": "^1.7.0",
+        "@lvce-editor/web-socket-server": "^2.1.0",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@lvce-editor/rpc/node_modules/@lvce-editor/json-rpc": {
@@ -2607,191 +2106,15 @@
         "@lvce-editor/ripgrep": "^5.1.0"
       }
     },
-    "node_modules/@lvce-editor/search-process/node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@lvce-editor/search-process/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lvce-editor/server": {
-      "version": "0.93.19",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.93.19.tgz",
-      "integrity": "sha512-dN1RCJI/FTrJJdJKTfufCMJbZgmIBb63DMsRQZApWVx3tCb0nLCLaaa5+UkHp97KF3toZmjK+vxV+IniNAgGMQ==",
+      "version": "0.99.17",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.99.17.tgz",
+      "integrity": "sha512-v+sjeutvkXXJEGOYV6P58ghozX5blpEHlKWY0qrZ/mHIeL48U65+anF43lMUTsbEbOCqLK/GnG/f5a9RcvwwdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.93.19",
-        "@lvce-editor/static-server": "0.93.19"
+        "@lvce-editor/shared-process": "0.99.17",
+        "@lvce-editor/static-server": "0.99.17"
       },
       "bin": {
         "server": "bin/server.js"
@@ -2800,16 +2123,316 @@
         "node": ">=24"
       }
     },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/assert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.9.0.tgz",
+      "integrity": "sha512-EPOXml+iWU38g0h71yv/nPaL1Xz/S72ICORPrR8shtoTqeoZmFzD8bH1dphr/xzYPaU97yEQo1Zen33aH111Uw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/embeds-process": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.15.0.tgz",
+      "integrity": "sha512-Z9B7YS7KAzia8lI1XR4Grx5Rl+OX2ow5PuAePLh1n4gx5BB40VeJX7Jj9scOZRclUQQmhCkH6MQt28jhIXNQ4A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "embeds-process": "bin/embedsProcess.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/extension-host-helper-process": {
+      "version": "0.99.17",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.99.17.tgz",
+      "integrity": "sha512-jHWmvJ7SCzo/PVaTs2QSXRM1dsarK+lOpy6MQf/ZTwgRcryg3LKOfHJ56G/wsyXvrTY74Me6sp6MdhZ85Gu0Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.9.0",
+        "@lvce-editor/command": "^2.0.0",
+        "@lvce-editor/rpc": "^6.16.0",
+        "@lvce-editor/verror": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/file-system-process": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.12.0.tgz",
+      "integrity": "sha512-fHn8/9SNNsvTXhekJBCHZ24+ZsBHaisjPep7mipuAeWxTUdN6KTyfY9hpleKPv/VOlA1o4ENueQkNFhoFesftw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "trash": "^10.1.1",
+        "ws": "^8.21.1"
+      },
+      "bin": {
+        "file-system-process": "bin/fileSystemProcess.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/file-watcher-process": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.12.0.tgz",
+      "integrity": "sha512-3nLW4QWoH9eLpQ2bcKrawNxH7q2aLbdH0+E19kmlukOTM+HWmIj9dnJKr3zPiOKOnUjE/S0bZwB1gL+2Arbd4g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "chokidar": "^5.0.0"
+      },
+      "bin": {
+        "file-watcher-process": "bin/fileWatcherProcess.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/ipc": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.10.0.tgz",
+      "integrity": "sha512-iL4D4ou4iSOvVu2S7/L20JHDavOYcA0o2y8HDQYdksBkK52Dlbt4U1f96DC2FMfKl/6uTBuZFNL8hCapYZMa6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/verror": "^1.7.0",
+        "@lvce-editor/web-socket-server": "^2.1.0",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/json-rpc": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.6.0.tgz",
+      "integrity": "sha512-T9zeMKn7Yk6QpMVY/RK5YzCp3VnG53jyHJ7gbC+CukuzlXMngj/TzR1mNkqEK8X3rFG+fxOAHrRKik+EE4cVAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/process-explorer": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.14.0.tgz",
+      "integrity": "sha512-PfJKcKPyqoxOhMJLXFMSTz9mrzWvK+rYgo3lZQQFBdEEwuC/m8laV4eppvKMucWsLJPfTCKFc1gtMqpXfSLUVw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "process-explorer": "bin/processExplorer.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@vscode/windows-process-tree": "^0.8.0"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/pty-host": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.7.0.tgz",
+      "integrity": "sha512-wx/4AUOJJfPVBlgueNrF/lFODN2575KIwfE5vHCl26jFr8qWJHvmypv/91eoq4whA5wGzH+tjEvO4t4FT8GSrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@lvce-editor/command": "^2.0.0"
+      },
+      "bin": {
+        "pty-host": "bin/ptyHost.js"
+      },
+      "optionalDependencies": {
+        "node-pty": "1.1.0-beta34"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/rpc-registry": {
+      "version": "9.48.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.48.0.tgz",
+      "integrity": "sha512-GHbf/Nzn2x30gk6cS600LVnbbPwUCPnjxtG9Kl0AHtUNx6SYeFKCfA/LftEUKg934TEG1WcvSkgo1vG3s0m9Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/constants": "^5.26.0",
+        "@lvce-editor/rpc": "^6.4.0"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/search-process": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.7.0.tgz",
+      "integrity": "sha512-eAyrQ8TakmyKXffDy0hDcsKVoZ6du44kos4XFeDnedfsd1znIBrsnF6mMplixMdL619Cd90kTXA739B7QMorRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "execa": "^9.6.1",
+        "ws": "^8.21.1"
+      },
+      "bin": {
+        "search-process": "bin/searchProcess.js"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "optionalDependencies": {
+        "@lvce-editor/ripgrep": "^5.2.0"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/shared-process": {
+      "version": "0.99.17",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.99.17.tgz",
+      "integrity": "sha512-dPsWD0rZZKKd6qsykbCPraRU1j0c8i8tmPieRz1GOjRcfep90/rzd+qRtYScnthJQq7gaB5ejesnAFjm01JyNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "1.9.0",
+        "@lvce-editor/extension-host-helper-process": "0.99.17",
+        "@lvce-editor/ipc": "16.10.0",
+        "@lvce-editor/json-rpc": "8.6.0",
+        "@lvce-editor/jsonc-parser": "1.5.0",
+        "@lvce-editor/pretty-error": "2.0.0",
+        "@lvce-editor/process-explorer": "3.14.0",
+        "@lvce-editor/rpc-registry": "9.48.0",
+        "@lvce-editor/verror": "1.7.0",
+        "is-object": "^1.0.2",
+        "markdown-it": "^15.0.0",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=24"
+      },
+      "optionalDependencies": {
+        "@lvce-editor/embeds-process": "4.15.0",
+        "@lvce-editor/file-system-process": "5.12.0",
+        "@lvce-editor/file-watcher-process": "4.12.0",
+        "@lvce-editor/network-process": "5.2.0",
+        "@lvce-editor/preload": "1.5.0",
+        "@lvce-editor/preview-process": "11.0.0",
+        "@lvce-editor/pty-host": "8.7.0",
+        "@lvce-editor/search-process": "15.7.0",
+        "@lvce-editor/typescript-compile-process": "5.8.0",
+        "open": "^11.0.0",
+        "tail": "^2.2.6",
+        "tmp-promise": "^3.0.3",
+        "trash": "^10.1.1"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/@lvce-editor/typescript-compile-process": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.8.0.tgz",
+      "integrity": "sha512-kJ/NDVYT/KirvB/qAo8f0rVDJKgaRyCrYZ5c5W8B2bQ4iQLnQ68FHJcIKypRa6vN7bfI544xfl7laqMOhZZ28w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "typescript-compile-process": "bin/typescriptCompileProcess.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/argparse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
+      "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "Python-2.0"
+    },
+    "node_modules/@lvce-editor/server/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/linkify-it": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^3.0.0"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/markdown-it": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.0.tgz",
+      "integrity": "sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^3.0.0",
+        "entities": "^8.0.0",
+        "linkify-it": "^6.0.0",
+        "mdurl": "^2.1.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^3.0.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/@lvce-editor/server/node_modules/uc.micro": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.93.19",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.93.19.tgz",
-      "integrity": "sha512-dVhv+03VRkDJFpzzIFL0QsDHPtaW4348xsEkifeByhWH4SyoTkzo+YcVpKF7OBDxaHYHNVusTmSgxfJ0+uBrpQ==",
+      "version": "0.93.25",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.93.25.tgz",
+      "integrity": "sha512-+ny25vPmpvwIVzL0DnJZRjL9EsuA2npjkCp43e5O4sZCjMC2RS62QDd+J7fUTQRIDiBB6fHIMH1Eq8cvK66qsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.7.0",
         "@lvce-editor/auth-process": "1.10.0",
-        "@lvce-editor/extension-host-helper-process": "0.93.19",
+        "@lvce-editor/extension-host-helper-process": "0.93.25",
         "@lvce-editor/ipc": "16.4.0",
         "@lvce-editor/json-rpc": "8.3.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -2841,9 +2464,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.93.19",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.93.19.tgz",
-      "integrity": "sha512-9y/ysS9bRxXqguLV7L/nlz0feJ+lz41N16ZgtXmEagMyDhm3gD0uf2y9NMvVtPCueYZ//gmvqC3ANvhMznSh4w==",
+      "version": "0.99.17",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.99.17.tgz",
+      "integrity": "sha512-mCQ5ZRgAEH3TsGfAWDagMvinSFdmtpjgpxXfTj8plCCoDR82eO7MdUkRuKPPZMwnqTzQylnsq1l5k2IuGzMFRQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3716,22 +3339,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
-      }
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.60.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -5589,16 +5196,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cacheable-request/node_modules/keyv": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@keyv/serialize": "^1.1.1"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -6041,6 +5638,129 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/execa/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/execa/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/exit-x": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/exit-x/-/exit-x-0.2.2.tgz",
@@ -6162,6 +5882,22 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fill-range": {
@@ -6396,16 +6132,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
-    "node_modules/got/node_modules/keyv": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/graceful-fs": {
@@ -6702,6 +6428,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -6720,6 +6459,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-windows": {
@@ -8022,6 +7774,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
     "node_modules/knip": {
       "version": "6.29.0",
       "resolved": "https://registry.npmjs.org/knip/-/knip-6.29.0.tgz",
@@ -8918,53 +8680,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.60.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/powershell-utils": {
@@ -10599,6 +10314,69 @@
       "integrity": "sha512-hVQqzWvN77taTFMD6SFNxgDgPGVxvAmp8gfgNU13ZTWaaGq1t6fiy8tTZVF+hsWqZzUzsSa+f80h32NSVUtn5g==",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/e2e/node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/e2e/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "packages/e2e/node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "packages/e2e/node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "packages/extension": {
       "name": "builtin.language-features-html",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "type": "module",
   "devDependencies": {
     "@lvce-editor/package-extension": "^3.2.0",
-    "@lvce-editor/server": "^0.93.19",
+    "@lvce-editor/server": "^0.99.17",
     "jest": "^30.4.2",
     "knip": "^6.29.0",
     "ts-jest": "^29.4.11",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -11,6 +11,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@lvce-editor/shared-process": "^0.93.19"
+    "@lvce-editor/shared-process": "^0.99.17"
   }
 }

--- a/packages/e2e/src/html.auto-closing-tag.ts
+++ b/packages/e2e/src/html.auto-closing-tag.ts
@@ -1,0 +1,19 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'html.auto-closing-tag'
+
+export const test: Test = async ({ Command, FileSystem, Main, Editor, Locator, expect }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/test.html`, '<h1><')
+  await Main.openUri(`${tmpDir}/test.html`)
+  await Editor.setCursor(0, 5)
+
+  // act
+  const editorId = await Command.execute('GetActiveEditor.getActiveEditorId')
+  await Command.execute('Viewlet.executeViewletCommand', editorId, 'typeWithAutoClosing', '/')
+
+  // assert
+  const editor = Locator('.Editor')
+  await expect(editor).toHaveText('<h1></h1>')
+}


### PR DESCRIPTION
Summary:
- run HTML language providers on the current full document runtime
- add end-to-end coverage for typing `/` after `<` and inserting the matching closing tag